### PR TITLE
"Show more" won't appear when all options are displayed

### DIFF
--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
@@ -4,7 +4,7 @@ $_showMore = Mage::helper('catalin_seo')->getShowMore();
 ?>
 <ol>
     <?php foreach ($this->getItems() as $_key=>$_item): ?>
-        <li<?php if($_showMore && $_key > $_showMore): ?> class="filter_hide"<?php endif; ?>>
+        <li<?php if($_showMore && $_key >= $_showMore): ?> class="filter_hide"<?php endif; ?>>
             <?php if ($_item->getCount() > 0): ?>
                 <a href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>" <?php echo $_nofollow; ?> >
                     <input type="checkbox"<?php if ($_item->isSelected()): ?> checked="checked" <?php endif; ?>/>


### PR DESCRIPTION
Bugfix where "Show more" appeared, even though all the options are already displayed. This also fixes the issue that the number of items to display before showing the "Show more" link is now correct.